### PR TITLE
Improve error reporting

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -45,7 +45,7 @@ impl FromStr for Client {
     /// definitions.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "Client";
-        let intent = "'#{client_session}':'#{client_last_session}'";
+        let intent = "'##{client_session}':'##{client_last_session}'";
         let parser = (quoted_nonempty_string, char(':'), quoted_string);
 
         let (_, (session_name, _, last_session_name)) = all_consuming(parser)

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -65,7 +65,7 @@ impl FromStr for Pane {
     /// definitions.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "Pane";
-        let intent = "#{pane_id}:#{pane_index}:#{?pane_active,true,false}:'#{pane_title}':'#{pane_current_command}':#{pane_current_path}";
+        let intent = "##{pane_id}:##{pane_index}:##{?pane_active,true,false}:'##{pane_title}':'##{pane_current_command}':##{pane_current_path}";
 
         let (_, pane) = all_consuming(parse::pane)
             .parse(input)

--- a/src/pane_id.rs
+++ b/src/pane_id.rs
@@ -25,7 +25,7 @@ impl FromStr for PaneId {
     /// Parse into `PaneId`. The `&str` must start with '%' followed by a `u32`.
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let desc = "PaneId";
-        let intent = "#{pane_id}";
+        let intent = "##{pane_id}";
 
         let (_, pane_id) = all_consuming(parse::pane_id)
             .parse(input)
@@ -91,7 +91,7 @@ mod tests {
             actual,
             Err(Error::ParseError {
                 desc: "PaneId",
-                intent: "#{pane_id}",
+                intent: "##{pane_id}",
                 err: _
             })
         ));

--- a/src/session.rs
+++ b/src/session.rs
@@ -62,7 +62,7 @@ impl FromStr for Session {
     /// definitions.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "Session";
-        let intent = "#{session_id}:'#{session_name}':#{session_path}";
+        let intent = "##{session_id}:'##{session_name}':##{session_path}";
 
         let (_, sess) = all_consuming(parse::session)
             .parse(input)
@@ -162,7 +162,7 @@ pub async fn new_session(
     let buffer = buffer.trim_end();
 
     let desc = "new-session";
-    let intent = "#{session_id}:#{window_id}:#{pane_id}";
+    let intent = "##{session_id}:##{window_id}:##{pane_id}";
     let (_, (new_session_id, _, new_window_id, _, new_pane_id)) =
         all_consuming((session_id, char(':'), window_id, char(':'), pane_id))
             .parse(buffer)

--- a/src/session_id.rs
+++ b/src/session_id.rs
@@ -25,7 +25,7 @@ impl FromStr for SessionId {
     /// `u16`.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "SessionId";
-        let intent = "#{session_id}";
+        let intent = "##{session_id}";
 
         let (_, sess_id) = all_consuming(parse::session_id)
             .parse(input)
@@ -77,7 +77,7 @@ mod tests {
             actual,
             Err(Error::ParseError {
                 desc: "SessionId",
-                intent: "#{session_id}",
+                intent: "##{session_id}",
                 err: _
             })
         ));

--- a/src/window.rs
+++ b/src/window.rs
@@ -75,7 +75,7 @@ impl FromStr for Window {
     /// definitions.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "Window";
-        let intent = "#{window_id}:#{window_index}:#{?window_active,true,false}:#{window_layout}:'#{window_name}':'#{window_linked_sessions_list}'";
+        let intent = "##{window_id}:##{window_index}:##{?window_active,true,false}:##{window_layout}:'##{window_name}':'##{window_linked_sessions_list}'";
 
         let (_, window) = all_consuming(parse::window)
             .parse(input)
@@ -202,7 +202,7 @@ pub async fn new_window(
     let buffer = buffer.trim_end();
 
     let desc = "new-window";
-    let intent = "#{window_id}:#{pane_id}";
+    let intent = "##{window_id}:##{pane_id}";
 
     let (_, (new_window_id, _, new_pane_id)) = all_consuming((window_id, char(':'), pane_id))
         .parse(buffer)

--- a/src/window_id.rs
+++ b/src/window_id.rs
@@ -25,7 +25,7 @@ impl FromStr for WindowId {
     /// `u16`.
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
         let desc = "WindowId";
-        let intent = "#{window_id}";
+        let intent = "##{window_id}";
 
         let (_, window_id) = all_consuming(parse::window_id)
             .parse(input)
@@ -78,7 +78,7 @@ mod tests {
             actual,
             Err(Error::ParseError {
                 desc: "WindowId",
-                intent: "#{window_id}",
+                intent: "##{window_id}",
                 err: _
             })
         ));


### PR DESCRIPTION
When printing error messages, the format strings are now escaped so that they don't get interpreted by tmux display-message.