### PR TITLE
More robust window creation

### DIFF
--- a/src/session_id.rs
+++ b/src/session_id.rs
@@ -35,11 +35,11 @@ impl FromStr for SessionId {
     }
 }
 
-// impl SessionId {
-//     pub fn as_str(&self) -> &str {
-//         &self.0
-//     }
-// }
+impl SessionId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
 
 pub(crate) mod parse {
     use super::*;

--- a/src/window.rs
+++ b/src/window.rs
@@ -173,7 +173,10 @@ pub async fn new_window(
     pane: &Pane,
     pane_command: Option<&str>,
 ) -> Result<(WindowId, PaneId)> {
-    let exact_session_name = format!("={}", session.name);
+    // Use session ID for targeting - it's unambiguous and immediately valid
+    // after session creation, unlike names which may have parsing issues
+    // (e.g., names containing colons) or brief lookup race conditions.
+    let target_session = session.id.as_str();
 
     let mut args = vec![
         "new-window",
@@ -183,7 +186,7 @@ pub async fn new_window(
         "-n",
         &window.name,
         "-t",
-        &exact_session_name,
+        target_session,
         "-P",
         "-F",
         "#{window_id}:#{pane_id}",


### PR DESCRIPTION
The original implementation `new_window()` created windows using session names, but it's more robust to use session ids. This fixes a race condition in tmux-backup on slow machines.