### PR TITLE
ci: harden workflows per security playbook and add renovate

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,59 @@
+# Reusable workflow: dependency audit via cargo-deny and cargo-pants.
+
+name: Cargo Audit
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  cargo-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Rust install
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cache crates from crates.io
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install tmux
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux
+          tmux -V
+
+      - name: cargo deny check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
+          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
+            tar zx --no-anchored cargo-deny --strip-components=1
+          chmod +x cargo-deny
+          mv cargo-deny ~/.cargo/bin/
+          cargo deny check
+
+      - name: cargo pants
+        run: |
+          cargo install --locked cargo-pants || true
+          cargo pants

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,48 @@
+# Reusable workflow: CI/CD supply chain security audits.
+
+name: CI Security
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+
+  poutine:
+    name: Poutine
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run poutine
+        uses: boostsecurityio/poutine-action@a563bfa02c3e093e52fb82f53eab0d3a0f348c34 # main (2026-04-07)
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: poutine

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -7,29 +7,35 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Quality checks & tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [stable]
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           # fetch-depth: ${{ github.event.pull_request.commits }}
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |
@@ -38,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: '${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles(''**/Cargo.lock'') }}'
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install tmux
         run: |
@@ -64,19 +70,12 @@ jobs:
           ./convco check -c .convco
           rm convco
 
-      - name: Quality - cargo deny check
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | jq -r '.tag_name')
-          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
-            tar zx --no-anchored cargo-deny --strip-components=1
-          chmod +x cargo-deny
-          mv cargo-deny ~/.cargo/bin/
-          cargo deny check
-
       - name: Quality - cargo outdated
         timeout-minutes: 20
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/kbknapp/cargo-outdated/releases/latest | jq -r '.tag_name')
+          VERSION=$(gh api repos/kbknapp/cargo-outdated/releases/latest --jq '.tag_name')
           curl -sSfL "https://github.com/kbknapp/cargo-outdated/releases/download/${VERSION}/cargo-outdated-${VERSION#v}-x86_64-unknown-linux-musl.tar.gz" | \
             tar zx
           chmod +x cargo-outdated
@@ -89,11 +88,6 @@ jobs:
       #     cargo install --locked cargo-udeps || true
       #     cargo udeps
 
-      - name: Quality - cargo pants
-        run: |
-          cargo install --locked cargo-pants || true
-          cargo pants
-
       - name: Build (dev)
         run: cargo build --all-features
 
@@ -102,3 +96,45 @@ jobs:
 
       - name: Test
         run: cargo test --all-features
+
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      cargo_lock: ${{ steps.filter.outputs.cargo_lock }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            cargo_lock:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.poutine.yml'
+              - '.github/zizmor.yml'
+              - 'renovate.json'
+
+  cargo-audit:
+    needs: changes
+    if: needs.changes.outputs.cargo_lock == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-audit.yml
+
+  ci-security:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: ./.github/workflows/ci-security.yml

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -6,26 +6,32 @@ on:
     branches:
       - staging
 
+permissions: {}
+
 jobs:
   test-versions:
     name: Tests on Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust: [1.85.0, beta, nightly]
 
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |
@@ -34,7 +40,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: '${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles(''**/Cargo.toml'') }}'
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install tmux
         run: |
@@ -62,6 +68,8 @@ jobs:
   test-other-platforms:
     name: Tests on
     runs-on: '${{ matrix.os }}'
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -75,17 +83,19 @@ jobs:
             toolchain: stable
     steps:
       - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         continue-on-error: false
         with:
           path: |
@@ -94,7 +104,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: '${{ runner.os }}-${{ matrix.target }}-cargo-${{ matrix.toolchain }}-${{ hashFiles(''Cargo.toml'') }}'
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('Cargo.toml') }}
 
       - name: Install tmux
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions: {}
 
 jobs:
   release:
@@ -13,15 +15,11 @@ jobs:
       contents: write
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # convco needs all history to create the changelog
           fetch-depth: 0
-
-      - name: Extract version
-        id: extract-version
-        run: |
-          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
+          persist-credentials: false
 
       - name: Download convco
         run: |
@@ -35,8 +33,11 @@ jobs:
           ./convco changelog -c .convco --max-versions 1 --include-hidden-sections > CHANGELOG.md
           rm convco convco-ubuntu.zip
 
-      - uses: ncipollo/release-action@v1
-        with:
-          artifacts: '*.zip,*.tar.xz'
-          bodyFile: 'CHANGELOG.md'
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release create "${TAG_NAME}" \
+            --title "${TAG_NAME}" \
+            --notes-file CHANGELOG.md

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,41 @@
+# Runs Renovate to check for dependency updates.
+# Triggers weekly on Friday afternoons, or manually via workflow_dispatch.
+
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 5' # every Friday at 16:00 UTC
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    environment: renovate
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@b67590ea780158ccd13192c22a3655a5231f869d # v46.1.8
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          configurationFile: renovate.json

--- a/.github/workflows/supply-chain-schedule.yml
+++ b/.github/workflows/supply-chain-schedule.yml
@@ -1,0 +1,24 @@
+# Scheduled supply chain audits: dependency vulnerabilities and CI security.
+
+name: Supply Chain Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 2' # Tuesday at 16:00 UTC
+    - cron: '0 16 * * 5' # Friday at 16:00 UTC
+
+permissions: {}
+
+jobs:
+  cargo-audit:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-audit.yml
+
+  ci-security:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    uses: ./.github/workflows/ci-security.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  # TODO: replace with action-name-based ignore once available
+  # (zizmorcore/zizmor#1086). All occurrences are dtolnay/rust-toolchain,
+  # which is intentional for multi-version matrix builds.
+  superfluous-actions:
+    ignore:
+      - cargo-audit.yml
+      - essentials.yml
+      - large-scope.yml

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -7,3 +7,4 @@ skip:
       - pkg:githubactions/dorny/paths-filter
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
+      - pkg:githubactions/renovatebot/github-action

--- a/.poutine.yml
+++ b/.poutine.yml
@@ -1,0 +1,9 @@
+skip:
+  # Well-known actions from trusted maintainers without GitHub's marketplace
+  # "verified creator" badge.
+  - rule: github_action_from_unverified_creator_used
+    purl:
+      - pkg:githubactions/dtolnay/rust-toolchain
+      - pkg:githubactions/dorny/paths-filter
+      - pkg:githubactions/zizmorcore/zizmor-action
+      - pkg:githubactions/boostsecurityio/poutine-action

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "gitAuthor": "graelo-ci-bot[bot] <274240725+graelo-ci-bot[bot]@users.noreply.github.com>",
+  "labels": [
+    "dependencies"
+  ],
+  "cargo": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to commit SHAs for supply chain safety",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group all patch updates into one PR",
+      "matchUpdateTypes": "patch",
+      "groupName": "patch updates"
+    },
+    {
+      "description": "Group all minor updates into one PR",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "minor updates"
+    }
+  ],
+  "schedule": [
+    "before 9pm on friday"
+  ]
+}


### PR DESCRIPTION
Apply the GitHub Actions hardening playbook to this repo, audited clean
by both zizmor and poutine.

All third-party actions are now pinned to commit SHAs. Workflows carry
top-level permissions: {} with least-privilege per-job grants, every
checkout sets persist-credentials: false, and the release tag filter is
tightened to strict semver. Cargo-deny and cargo-pants move into a
reusable cargo-audit.yml, and zizmor + poutine run in ci-security.yml —
both called conditionally from essentials.yml via dorny/paths-filter
and unconditionally twice a week from supply-chain-schedule.yml. The
crate cache only populates on pull_request events so a poisoned PR
cache cannot propagate to main builds. Since this is a library, the
release workflow swaps ncipollo/release-action for gh release create
and drops the (always-empty) artifact upload.

Renovate comes along because SHA pinning without an ongoing digest
bumper rots fast. It authenticates as the existing graelo-ci-bot
GitHub App via a renovate environment holding APP_CLIENT_ID /
APP_PRIVATE_KEY (configured in repo settings, not in this PR).

- [ ] Install graelo-ci-bot on graelo/tmux-lib
- [ ] Create renovate environment with APP_CLIENT_ID + APP_PRIVATE_KEY
- [ ] Trigger renovate.yml manually to verify first run