### PR TITLE
chore(rust): bump msrv 1.85 -> 1.95 and leverage new features

### DIFF
--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        rust: [1.85.0, beta, nightly]
+        rust: [1.95.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tmux-lib"
 version = "0.4.2"
-edition = "2021"
-rust-version = "1.85.0"
+edition = "2024"
+rust-version = "1.95.0"
 description = "Tmux helper functions."
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![crate](https://img.shields.io/crates/v/tmux-lib.svg)](https://crates.io/crates/tmux-lib)
 [![documentation](https://docs.rs/tmux-lib/badge.svg)](https://docs.rs/tmux-lib)
-[![minimum rustc 1.85](https://img.shields.io/badge/rustc-1.85+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.95](https://img.shields.io/badge/rustc-1.95+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/graelo/tmux-lib/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/tmux-lib/actions)
 
 <!-- cargo-sync-readme start -->
 
 Read or manipulate Tmux.
 
-Version requirement: _rustc 1.85.0+_
+Version requirement: _rustc 1.95.0+_
 
 ```toml
 [dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,14 +2,14 @@
 
 use std::str::FromStr;
 
-use nom::{character::complete::char, combinator::all_consuming, Parser};
+use nom::{Parser, character::complete::char, combinator::all_consuming};
 use serde::{Deserialize, Serialize};
 use smol::process::Command;
 
 use crate::{
-    error::{map_add_intent, Error},
-    parse::{quoted_nonempty_string, quoted_string},
     Result,
+    error::{Error, map_add_intent},
+    parse::{quoted_nonempty_string, quoted_string},
 };
 
 /// A Tmux client.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -12,15 +12,15 @@
 //! The parser in this module returns the corresponding [`WindowLayout`].
 
 use nom::{
+    IResult, Parser,
     branch::alt,
     character::complete::{char, digit1, hex_digit1},
     combinator::{all_consuming, map_res},
     multi::separated_list1,
     sequence::delimited,
-    IResult, Parser,
 };
 
-use crate::{error::map_add_intent, Result};
+use crate::{Result, error::map_add_intent};
 
 /// Represent a parsed window layout.
 #[derive(Debug, PartialEq, Eq)]
@@ -193,8 +193,8 @@ fn container(input: &str) -> IResult<&str, Container> {
 mod tests {
 
     use super::{
-        coordinates, dimensions, layout_id, single_pane, vert_split, window_layout, Container,
-        Coordinates, Dimensions, Element, Split, WindowLayout,
+        Container, Coordinates, Dimensions, Element, Split, WindowLayout, coordinates, dimensions,
+        layout_id, single_pane, vert_split, window_layout,
     };
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Read or manipulate Tmux.
 //!
-//! Version requirement: _rustc 1.85.0+_
+//! Version requirement: _rustc 1.95.0+_
 //!
 //! ```toml
 //! [dependencies]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -7,19 +7,19 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, digit1, not_line_ending},
     combinator::{all_consuming, map_res},
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 use smol::process::Command;
 
 use crate::{
-    error::{check_empty_process_output, check_process_success, map_add_intent, Error},
-    pane_id::{parse::pane_id, PaneId},
+    Result,
+    error::{Error, check_empty_process_output, check_process_success, map_add_intent},
+    pane_id::{PaneId, parse::pane_id},
     parse::{boolean, quoted_nonempty_string, quoted_string},
     window_id::WindowId,
-    Result,
 };
 
 /// A Tmux pane.

--- a/src/pane_id.rs
+++ b/src/pane_id.rs
@@ -4,14 +4,14 @@ use std::fmt;
 use std::str::FromStr;
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, digit1},
     combinator::all_consuming,
     sequence::preceded,
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::error::{map_add_intent, Error};
+use crate::error::{Error, map_add_intent};
 
 /// The id of a Tmux pane.
 ///
@@ -56,7 +56,7 @@ impl fmt::Display for PaneId {
 }
 
 pub(crate) mod parse {
-    use super::{char, digit1, preceded, IResult, PaneId, Parser};
+    use super::{IResult, PaneId, Parser, char, digit1, preceded};
 
     pub(crate) fn pane_id(input: &str) -> IResult<&str, PaneId> {
         let (input, digit) = preceded(char('%'), digit1).parse(input)?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,7 +8,6 @@ use nom::{
 };
 
 /// Return the `&str` between single quotes. The returned string may be empty.
-#[allow(unused)]
 pub(crate) fn quoted_string(input: &str) -> IResult<&str, &str> {
     let esc = escaped(none_of("\\\'"), '\\', tag("'"));
     let esc_or_empty = alt((esc, tag("")));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,10 +1,10 @@
 use nom::{
+    IResult, Parser,
     branch::alt,
     bytes::complete::{escaped, tag},
     character::complete::none_of,
     combinator::value,
     sequence::delimited,
-    IResult, Parser,
 };
 
 /// Return the `&str` between single quotes. The returned string may be empty.

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,11 +2,11 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use smol::{future, process::Command, Timer};
+use smol::{Timer, future, process::Command};
 
 use crate::{
-    error::{check_empty_process_output, Error},
     Result,
+    error::{Error, check_empty_process_output},
 };
 
 /// Maximum time to wait for the server to become ready.

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,22 +6,22 @@
 use std::{path::PathBuf, str::FromStr};
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, not_line_ending},
     combinator::all_consuming,
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 use smol::process::Command;
 
 use crate::{
-    error::{check_process_success, map_add_intent, Error},
-    pane::Pane,
-    pane_id::{parse::pane_id, PaneId},
-    parse::quoted_nonempty_string,
-    session_id::{parse::session_id, SessionId},
-    window::Window,
-    window_id::{parse::window_id, WindowId},
     Result,
+    error::{Error, check_process_success, map_add_intent},
+    pane::Pane,
+    pane_id::{PaneId, parse::pane_id},
+    parse::quoted_nonempty_string,
+    session_id::{SessionId, parse::session_id},
+    window::Window,
+    window_id::{WindowId, parse::window_id},
 };
 
 /// A Tmux session.

--- a/src/session_id.rs
+++ b/src/session_id.rs
@@ -3,14 +3,14 @@
 use std::str::FromStr;
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, digit1},
     combinator::all_consuming,
     sequence::preceded,
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::error::{map_add_intent, Error};
+use crate::error::{Error, map_add_intent};
 
 /// The id of a Tmux session.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,49 +1,8 @@
-/// Misc utilities.
-pub trait SliceExt {
-    fn trim(&self) -> &Self;
-    fn trim_trailing(&self) -> &Self;
-}
-
-fn is_whitespace(c: &u8) -> bool {
-    *c == b'\t' || *c == b' '
-}
-
-fn is_not_whitespace(c: &u8) -> bool {
-    !is_whitespace(c)
-}
-
-impl SliceExt for [u8] {
-    /// Trim leading and trailing whitespaces (`\t` and ` `) in a `&[u8]`
-    fn trim(&self) -> &[u8] {
-        if let Some(first) = self.iter().position(is_not_whitespace) {
-            if let Some(last) = self.iter().rposition(is_not_whitespace) {
-                &self[first..last + 1]
-            } else {
-                unreachable!();
-            }
-        } else {
-            &[]
-        }
-    }
-
-    /// Trim trailing whitespaces (`\t` and ` `) in a `&[u8]`
-    fn trim_trailing(&self) -> &[u8] {
-        if let Some(last) = self.iter().rposition(is_not_whitespace) {
-            &self[0..last + 1]
-        } else {
-            &[]
-        }
-    }
-}
-
 /// Trim each line of the buffer.
 fn buf_trim_trailing(buf: &[u8]) -> Vec<&[u8]> {
-    let trimmed_lines: Vec<&[u8]> = buf
-        .split(|c| *c == b'\n')
-        .map(SliceExt::trim_trailing) // trim each line
-        .collect();
-
-    trimmed_lines
+    buf.split(|c| *c == b'\n')
+        .map(|line| line.trim_ascii_end())
+        .collect()
 }
 
 /// Drop all the last empty lines.
@@ -90,14 +49,14 @@ pub fn cleanup_captured_buffer(buffer: &[u8], drop_n_last_lines: usize) -> Vec<u
 
 #[cfg(test)]
 mod tests {
-    use super::{buf_trim_trailing, cleanup_captured_buffer, drop_last_empty_lines, SliceExt};
+    use super::{buf_trim_trailing, cleanup_captured_buffer, drop_last_empty_lines};
 
     #[test]
     fn trims_trailing_whitespaces() {
         let input = "  text   ".as_bytes();
         let expected = "  text".as_bytes();
 
-        let actual = input.trim_trailing();
+        let actual = input.trim_ascii_end();
         assert_eq!(actual, expected);
     }
 
@@ -106,7 +65,7 @@ mod tests {
         let input = "  text   ".as_bytes();
         let expected = "text".as_bytes();
 
-        let actual = input.trim();
+        let actual = input.trim_ascii();
         assert_eq!(actual, expected);
     }
 
@@ -140,22 +99,22 @@ mod tests {
     #[test]
     fn test_trim_only_whitespace() {
         let input = "   \t  ".as_bytes();
-        assert_eq!(input.trim(), &[]);
-        assert_eq!(input.trim_trailing(), &[]);
+        assert_eq!(input.trim_ascii(), &[]);
+        assert_eq!(input.trim_ascii_end(), &[]);
     }
 
     #[test]
     fn test_trim_empty() {
         let input = "".as_bytes();
-        assert_eq!(input.trim(), &[]);
-        assert_eq!(input.trim_trailing(), &[]);
+        assert_eq!(input.trim_ascii(), &[]);
+        assert_eq!(input.trim_ascii_end(), &[]);
     }
 
     #[test]
     fn test_trim_tabs() {
         let input = "\t\ttext\t\t".as_bytes();
-        assert_eq!(input.trim(), "text".as_bytes());
-        assert_eq!(input.trim_trailing(), "\t\ttext".as_bytes());
+        assert_eq!(input.trim_ascii(), "text".as_bytes());
+        assert_eq!(input.trim_ascii_end(), "\t\ttext".as_bytes());
     }
 
     #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -7,21 +7,21 @@ use std::str::FromStr;
 use smol::process::Command;
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, digit1},
     combinator::{all_consuming, map_res, recognize},
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::{check_empty_process_output, check_process_success, map_add_intent, Error},
+    Result,
+    error::{Error, check_empty_process_output, check_process_success, map_add_intent},
     layout::{self, window_layout},
     pane::Pane,
-    pane_id::{parse::pane_id, PaneId},
+    pane_id::{PaneId, parse::pane_id},
     parse::{boolean, quoted_nonempty_string},
     session::Session,
-    window_id::{parse::window_id, WindowId},
-    Result,
+    window_id::{WindowId, parse::window_id},
 };
 
 /// A Tmux window.
@@ -234,8 +234,8 @@ pub async fn select_window(window_id: &WindowId) -> Result<()> {
 mod tests {
     use super::Window;
     use super::WindowId;
-    use crate::pane_id::PaneId;
     use crate::Result;
+    use crate::pane_id::PaneId;
     use std::str::FromStr;
 
     #[test]
@@ -282,9 +282,7 @@ mod tests {
                 id: WindowId::from_str("@3").unwrap(),
                 index: 2,
                 is_active: false,
-                layout: String::from(
-                    "9e8b,334x85,0,0{167x85,0,0,8,166x85,168,0,9}",
-                ),
+                layout: String::from("9e8b,334x85,0,0{167x85,0,0,8,166x85,168,0,9}"),
                 name: String::from("th-bits"),
                 sessions: vec![String::from("pytorch")],
             },
@@ -292,9 +290,7 @@ mod tests {
                 id: WindowId::from_str("@4").unwrap(),
                 index: 3,
                 is_active: false,
-                layout: String::from(
-                    "64ef,334x85,0,0,10",
-                ),
+                layout: String::from("64ef,334x85,0,0,10"),
                 name: String::from("docker-pytorch"),
                 sessions: vec![String::from("pytorch")],
             },
@@ -302,9 +298,7 @@ mod tests {
                 id: WindowId::from_str("@5").unwrap(),
                 index: 0,
                 is_active: true,
-                layout: String::from(
-                    "64f0,334x85,0,0,11",
-                ),
+                layout: String::from("64f0,334x85,0,0,11"),
                 name: String::from("ben"),
                 sessions: vec![String::from("rust")],
             },
@@ -312,9 +306,7 @@ mod tests {
                 id: WindowId::from_str("@6").unwrap(),
                 index: 1,
                 is_active: false,
-                layout: String::from(
-                    "64f1,334x85,0,0,12",
-                ),
+                layout: String::from("64f1,334x85,0,0,12"),
                 name: String::from("pyo3"),
                 sessions: vec![String::from("rust")],
             },
@@ -322,9 +314,7 @@ mod tests {
                 id: WindowId::from_str("@7").unwrap(),
                 index: 2,
                 is_active: false,
-                layout: String::from(
-                    "64f2,334x85,0,0,13",
-                ),
+                layout: String::from("64f2,334x85,0,0,13"),
                 name: String::from("mdns-repeater"),
                 sessions: vec![String::from("rust")],
             },
@@ -332,9 +322,7 @@ mod tests {
                 id: WindowId::from_str("@8").unwrap(),
                 index: 0,
                 is_active: true,
-                layout: String::from(
-                    "64f3,334x85,0,0,14",
-                ),
+                layout: String::from("64f3,334x85,0,0,14"),
                 name: String::from("combine"),
                 sessions: vec![String::from("swift")],
             },
@@ -342,9 +330,7 @@ mod tests {
                 id: WindowId::from_str("@9").unwrap(),
                 index: 0,
                 is_active: false,
-                layout: String::from(
-                    "64f4,334x85,0,0,15",
-                ),
+                layout: String::from("64f4,334x85,0,0,15"),
                 name: String::from("copyrat"),
                 sessions: vec![String::from("tmux-hacking")],
             },

--- a/src/window_id.rs
+++ b/src/window_id.rs
@@ -3,14 +3,14 @@
 use std::str::FromStr;
 
 use nom::{
+    IResult, Parser,
     character::complete::{char, digit1},
     combinator::all_consuming,
     sequence::preceded,
-    IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::error::{map_add_intent, Error};
+use crate::error::{Error, map_add_intent};
 
 /// The id of a Tmux window.
 ///

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -238,33 +238,30 @@ mod session_tests {
 
             let panes = pane::available_panes().await.unwrap();
 
-            if let Some(window) = our_window {
-                let our_pane_ids = window.pane_ids();
-                let pane = panes.iter().find(|p| our_pane_ids.contains(&p.id));
+            if let Some(window) = our_window
+                && let Some(pane) = panes.iter().find(|p| window.pane_ids().contains(&p.id))
+            {
+                // Create a template session
+                let template_session = Session {
+                    id: SessionId::from_str("$0").unwrap(),
+                    name: new_session_name.clone(),
+                    dirpath: pane.dirpath.clone(),
+                };
 
-                if let Some(pane) = pane {
-                    // Create a template session
-                    let template_session = Session {
-                        id: SessionId::from_str("$0").unwrap(),
-                        name: new_session_name.clone(),
-                        dirpath: pane.dirpath.clone(),
-                    };
+                // Create the new session
+                let result = session::new_session(&template_session, window, pane, None).await;
+                assert!(result.is_ok(), "Failed to create session: {:?}", result);
 
-                    // Create the new session
-                    let result = session::new_session(&template_session, window, pane, None).await;
-                    assert!(result.is_ok(), "Failed to create session: {:?}", result);
+                let (sess_id, win_id, pane_id) = result.unwrap();
+                // Just verify they were created (IDs are opaque types)
+                let _ = sess_id;
+                assert!(win_id.as_str().starts_with('@'));
+                assert!(pane_id.as_str().starts_with('%'));
 
-                    let (sess_id, win_id, pane_id) = result.unwrap();
-                    // Just verify they were created (IDs are opaque types)
-                    let _ = sess_id;
-                    assert!(win_id.as_str().starts_with('@'));
-                    assert!(pane_id.as_str().starts_with('%'));
-
-                    // Verify the session exists
-                    let sessions = session::available_sessions().await.unwrap();
-                    let found = sessions.iter().any(|s| s.name == new_session_name);
-                    assert!(found, "New session should exist");
-                }
+                // Verify the session exists
+                let sessions = session::available_sessions().await.unwrap();
+                let found = sessions.iter().any(|s| s.name == new_session_name);
+                assert!(found, "New session should exist");
             }
         });
     }
@@ -332,34 +329,31 @@ mod window_tests {
 
             let panes = pane::available_panes().await.unwrap();
 
-            if let Some(win) = our_window {
-                let our_pane_ids = win.pane_ids();
-                let pane = panes.iter().find(|p| our_pane_ids.contains(&p.id));
+            if let Some(win) = our_window
+                && let Some(pane) = panes.iter().find(|p| win.pane_ids().contains(&p.id))
+            {
+                // Create a template window
+                let template_window = Window {
+                    id: WindowId::from_str("@0").unwrap(),
+                    index: 0,
+                    is_active: false,
+                    layout: String::new(),
+                    name: window_name.to_string(),
+                    sessions: vec![session_name.clone()],
+                };
 
-                if let Some(pane) = pane {
-                    // Create a template window
-                    let template_window = Window {
-                        id: WindowId::from_str("@0").unwrap(),
-                        index: 0,
-                        is_active: false,
-                        layout: String::new(),
-                        name: window_name.to_string(),
-                        sessions: vec![session_name.clone()],
-                    };
+                // Create new window
+                let result = window::new_window(session, &template_window, pane, None).await;
+                assert!(result.is_ok(), "Failed to create window: {:?}", result);
 
-                    // Create new window
-                    let result = window::new_window(session, &template_window, pane, None).await;
-                    assert!(result.is_ok(), "Failed to create window: {:?}", result);
+                let (win_id, pane_id) = result.unwrap();
+                assert!(win_id.as_str().starts_with('@'));
+                assert!(pane_id.as_str().starts_with('%'));
 
-                    let (win_id, pane_id) = result.unwrap();
-                    assert!(win_id.as_str().starts_with('@'));
-                    assert!(pane_id.as_str().starts_with('%'));
-
-                    // Verify window exists
-                    let windows = window::available_windows().await.unwrap();
-                    let found = windows.iter().any(|w| w.name == window_name);
-                    assert!(found, "New window should exist");
-                }
+                // Verify window exists
+                let windows = window::available_windows().await.unwrap();
+                let found = windows.iter().any(|w| w.name == window_name);
+                assert!(found, "New window should exist");
             }
         });
     }
@@ -480,24 +474,20 @@ mod pane_tests {
 
             let panes = pane::available_panes().await.unwrap();
 
-            if let Some(win) = our_window {
-                // Find a pane that belongs to our window
-                let our_pane_ids = win.pane_ids();
-                let our_pane = panes.iter().find(|p| our_pane_ids.contains(&p.id));
+            if let Some(win) = our_window
+                && let Some(p) = panes.iter().find(|p| win.pane_ids().contains(&p.id))
+            {
+                // Create new pane
+                let result = pane::new_pane(p, None, &win.id).await;
+                assert!(result.is_ok(), "Failed to create pane: {:?}", result);
 
-                if let Some(p) = our_pane {
-                    // Create new pane
-                    let result = pane::new_pane(p, None, &win.id).await;
-                    assert!(result.is_ok(), "Failed to create pane: {:?}", result);
+                let new_pane_id = result.unwrap();
+                assert!(new_pane_id.as_str().starts_with('%'));
 
-                    let new_pane_id = result.unwrap();
-                    assert!(new_pane_id.as_str().starts_with('%'));
-
-                    // Verify the new pane exists in the pane list
-                    let panes_after = pane::available_panes().await.unwrap();
-                    let found = panes_after.iter().any(|p| p.id == new_pane_id);
-                    assert!(found, "New pane {} should exist", new_pane_id);
-                }
+                // Verify the new pane exists in the pane list
+                let panes_after = pane::available_panes().await.unwrap();
+                let found = panes_after.iter().any(|p| p.id == new_pane_id);
+                assert!(found, "New pane {} should exist", new_pane_id);
             }
         });
     }


### PR DESCRIPTION
Bump MSRV to 1.95 and edition from 2021 to 2024, then adopt two features this unlocks.

The custom `SliceExt` trait (`trim` / `trim_trailing` on `&[u8]`) is replaced by std's `trim_ascii()` / `trim_ascii_end()`, stabilized in 1.80. This drops ~50 lines of hand-rolled whitespace handling. The std version trims all ASCII whitespace (not just tab and space), which is slightly broader but more correct for tmux output.

Three nested `if let` patterns in integration tests are flattened into single conditions using let chains, available in edition 2024. A stale `#[allow(unused)]` on `quoted_string` (which is used in both `pane.rs` and `client.rs`) is also removed.

- [x] `cargo +nightly clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib` — 113 tests pass