### PR TITLE
test: improve unit and doc test coverage

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -118,6 +118,13 @@ impl Split {
 }
 
 /// Parse the Tmux layout string description and return the pane-ids.
+///
+/// ```
+/// use tmux_lib::layout::parse_window_layout;
+///
+/// let layout = parse_window_layout("9e8b,334x85,0,0{167x85,0,0,8,166x85,168,0,9}").unwrap();
+/// assert_eq!(layout.pane_ids(), vec![8, 9]);
+/// ```
 pub fn parse_window_layout(input: &str) -> Result<WindowLayout> {
     let desc = "window-layout";
     let intent = "window-layout";

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -23,6 +23,19 @@ use crate::{
 };
 
 /// A Tmux pane.
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::pane::Pane;
+///
+/// let line = "%20:0:false:'rmbp':'nvim':/Users/graelo/code/rust/tmux-backup";
+/// let pane = Pane::from_str(line).unwrap();
+///
+/// assert_eq!(pane.id.as_str(), "%20");
+/// assert_eq!(pane.index, 0);
+/// assert!(!pane.is_active);
+/// assert_eq!(pane.command, "nvim");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Pane {
     /// Pane identifier, e.g. `%37`.

--- a/src/pane_id.rs
+++ b/src/pane_id.rs
@@ -16,6 +16,18 @@ use crate::error::{Error, map_add_intent};
 /// The id of a Tmux pane.
 ///
 /// This wraps the raw tmux representation (`%12`).
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::pane_id::PaneId;
+///
+/// let id = PaneId::from_str("%42").unwrap();
+/// assert_eq!(id.as_str(), "%42");
+///
+/// // Can also be created from a u16
+/// let id = PaneId::from(&7u16);
+/// assert_eq!(id.as_str(), "%7");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PaneId(pub String);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -108,16 +108,23 @@ pub async fn show_options(global: bool) -> Result<HashMap<String, String>> {
 
     let output = Command::new("tmux").args(&args).output().await?;
     let buffer = String::from_utf8(output.stdout)?;
-    let pairs: HashMap<String, String> = buffer
+
+    Ok(parse_options(&buffer))
+}
+
+/// Parse the output of `tmux show-options` into a `HashMap`.
+///
+/// Lines without a space (bare flags) are skipped. Values that are empty or
+/// equal to `''` are filtered out.
+fn parse_options(buffer: &str) -> HashMap<String, String> {
+    buffer
         .trim_end()
         .split('\n')
         .filter_map(|s| s.split_once(' '))
         .map(|(k, v)| (k, v.trim_start()))
         .filter(|(_, v)| !v.is_empty() && v != &"''")
         .map(|(k, v)| (k.to_string(), v.to_string()))
-        .collect();
-
-    Ok(pairs)
+        .collect()
 }
 
 /// Return the `"default-command"` used to start a pane, falling back to `"default shell"` if none.
@@ -140,14 +147,65 @@ pub async fn default_command() -> Result<String> {
 
     all_options
         .get("default-command")
-        // .map(|cmd| {
-        //     if cmd.trim_end() == "''" {
-        //         &default_shell
-        //     } else {
-        //         cmd
-        //     }
-        // })
         .or(Some(&default_shell))
         .ok_or(Error::TmuxConfig("no default-command nor default-shell"))
         .map(|cmd| cmd.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_options;
+
+    #[test]
+    fn parse_options_typical_output() {
+        let input = "default-shell /bin/zsh\nstatus on\nhistory-limit 10000\n";
+        let opts = parse_options(input);
+
+        assert_eq!(opts.get("default-shell").unwrap(), "/bin/zsh");
+        assert_eq!(opts.get("status").unwrap(), "on");
+        assert_eq!(opts.get("history-limit").unwrap(), "10000");
+    }
+
+    #[test]
+    fn parse_options_skips_bare_flags() {
+        let input = "destroy-unattached\ndefault-shell /bin/zsh\nsilence-action\n";
+        let opts = parse_options(input);
+
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts.get("default-shell").unwrap(), "/bin/zsh");
+        assert!(!opts.contains_key("destroy-unattached"));
+        assert!(!opts.contains_key("silence-action"));
+    }
+
+    #[test]
+    fn parse_options_filters_empty_values() {
+        let input = "default-command ''\ndefault-shell /bin/zsh\n";
+        let opts = parse_options(input);
+
+        assert!(!opts.contains_key("default-command"));
+        assert_eq!(opts.get("default-shell").unwrap(), "/bin/zsh");
+    }
+
+    #[test]
+    fn parse_options_empty_input() {
+        let opts = parse_options("");
+        assert!(opts.is_empty());
+    }
+
+    #[test]
+    fn parse_options_value_with_spaces() {
+        let input = "status-left [#S] #H\nstatus on\n";
+        let opts = parse_options(input);
+
+        assert_eq!(opts.get("status-left").unwrap(), "[#S] #H");
+        assert_eq!(opts.get("status").unwrap(), "on");
+    }
+
+    #[test]
+    fn parse_options_trims_spaces_between_key_and_value() {
+        let input = "key   value-with-extra-spaces\n";
+        let opts = parse_options(input);
+
+        assert_eq!(opts.get("key").unwrap(), "value-with-extra-spaces");
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -25,6 +25,17 @@ use crate::{
 };
 
 /// A Tmux session.
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::session::Session;
+///
+/// let line = "$1:'pytorch':/Users/graelo/ml/pytorch";
+/// let session = Session::from_str(line).unwrap();
+///
+/// assert_eq!(session.id.as_str(), "$1");
+/// assert_eq!(session.name, "pytorch");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Session {
     /// Session identifier, e.g. `$3`.

--- a/src/session_id.rs
+++ b/src/session_id.rs
@@ -15,6 +15,14 @@ use crate::error::{Error, map_add_intent};
 /// The id of a Tmux session.
 ///
 /// This wraps the raw tmux representation (`$11`).
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::session_id::SessionId;
+///
+/// let id = SessionId::from_str("$3").unwrap();
+/// assert_eq!(id.as_str(), "$3");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionId(String);
 
@@ -36,6 +44,8 @@ impl FromStr for SessionId {
 }
 
 impl SessionId {
+    /// Extract a string slice containing the raw representation.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,16 +14,26 @@ fn drop_last_empty_lines<'a>(lines: &[&'a [u8]]) -> Vec<&'a [u8]> {
     }
 }
 
-/// This function processes a pane captured bufer.
+/// Process a pane captured buffer.
 ///
 /// - All lines are trimmed after capture because tmux does not allow capturing escape codes and
 ///   trimming lines.
-/// - If `drop_n_last_lines` is greater than 0, the n last line are not captured. This is used only
+/// - If `drop_n_last_lines` is greater than 0, the n last lines are not captured. This is used only
 ///   for panes with a zsh prompt, in order to avoid polluting the history with new prompts on
 ///   restore.
 /// - In addition, the last line has an additional ascii reset escape code because tmux does not
 ///   capture it.
 ///
+/// ```
+/// use tmux_lib::utils::cleanup_captured_buffer;
+///
+/// let buffer = b"line1  \nline2\t\n\n\n";
+/// let result = cleanup_captured_buffer(buffer, 0);
+/// let output = String::from_utf8(result).unwrap();
+///
+/// // trailing whitespace trimmed, empty trailing lines dropped, reset code appended
+/// assert_eq!(output, "line1\nline2\x1b[0m\n");
+/// ```
 pub fn cleanup_captured_buffer(buffer: &[u8], drop_n_last_lines: usize) -> Vec<u8> {
     let trimmed_lines: Vec<&[u8]> = buf_trim_trailing(buffer);
     let mut buffer: Vec<&[u8]> = drop_last_empty_lines(&trimmed_lines);
@@ -194,5 +204,37 @@ mod tests {
         let lines: Vec<&[u8]> = vec![b"a", b"b", b"c"];
         let result = drop_last_empty_lines(&lines);
         assert_eq!(result, lines);
+    }
+
+    #[test]
+    fn test_cleanup_captured_buffer_tabs_are_trimmed() {
+        let input = "line1\t\t\nline2\t\n";
+        let result = cleanup_captured_buffer(input.as_bytes(), 0);
+        let result_str = String::from_utf8(result).unwrap();
+        assert_eq!(result_str, "line1\nline2\u{001b}[0m\n");
+    }
+
+    #[test]
+    fn test_cleanup_captured_buffer_mixed_trailing_whitespace() {
+        let input = "line1 \t \nline2\t  \t\n";
+        let result = cleanup_captured_buffer(input.as_bytes(), 0);
+        let result_str = String::from_utf8(result).unwrap();
+        assert_eq!(result_str, "line1\nline2\u{001b}[0m\n");
+    }
+
+    #[test]
+    fn test_cleanup_captured_buffer_no_trailing_newline() {
+        let input = "line1\nline2";
+        let result = cleanup_captured_buffer(input.as_bytes(), 0);
+        let result_str = String::from_utf8(result).unwrap();
+        assert_eq!(result_str, "line1\nline2\u{001b}[0m\n");
+    }
+
+    #[test]
+    fn test_buf_trim_trailing_preserves_leading_whitespace() {
+        let text = "  indented\n\tnested\n";
+        let actual = buf_trim_trailing(text.as_bytes());
+        assert_eq!(actual[0], "  indented".as_bytes());
+        assert_eq!(actual[1], "\tnested".as_bytes());
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -25,6 +25,19 @@ use crate::{
 };
 
 /// A Tmux window.
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::window::Window;
+///
+/// let line = "@5:0:true:64f0,334x85,0,0,11:'ben':'rust'";
+/// let window = Window::from_str(line).unwrap();
+///
+/// assert_eq!(window.id.as_str(), "@5");
+/// assert_eq!(window.index, 0);
+/// assert!(window.is_active);
+/// assert_eq!(window.name, "ben");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Window {
     /// Window identifier, e.g. `@3`.

--- a/src/window_id.rs
+++ b/src/window_id.rs
@@ -15,6 +15,14 @@ use crate::error::{Error, map_add_intent};
 /// The id of a Tmux window.
 ///
 /// This wraps the raw tmux representation (`@41`).
+///
+/// ```
+/// use std::str::FromStr;
+/// use tmux_lib::window_id::WindowId;
+///
+/// let id = WindowId::from_str("@10").unwrap();
+/// assert_eq!(id.as_str(), "@10");
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowId(String);
 
@@ -37,6 +45,7 @@ impl FromStr for WindowId {
 
 impl WindowId {
     /// Extract a string slice containing the raw representation.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }


### PR DESCRIPTION
Extract the option-parsing logic from `show_options` into a standalone `parse_options` function so it can be unit-tested without a live tmux server. Add 6 unit tests covering typical output, bare flags, empty values, empty input, values with spaces, and multi-space separators. Remove dead commented-out code in `default_command` that was superseded by upstream `''` filtering.

Add 4 edge case tests for `cleanup_captured_buffer` (tabs, mixed whitespace, missing trailing newline, leading whitespace preservation) and doc tests with runnable examples on all major public types: `PaneId`, `SessionId`, `WindowId`, `Pane`, `Session`, `Window`, `parse_window_layout`, `cleanup_captured_buffer`. Also add missing `#[must_use]` on `SessionId::as_str` and `WindowId::as_str` for consistency.

- [x] 138 nextest tests pass (up from 128)
- [x] 8 doc tests pass (all new)
- [x] `cargo +nightly clippy --all-targets --all-features -- -D warnings` clean