### PR TITLE
ci(renovate): enable automerge for patch and minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,14 +21,16 @@
     {
       "description": "Group all patch updates into one PR",
       "matchUpdateTypes": "patch",
-      "groupName": "patch updates"
+      "groupName": "patch updates",
+      "automerge": true
     },
     {
       "description": "Group all minor updates into one PR",
       "matchUpdateTypes": [
         "minor"
       ],
-      "groupName": "minor updates"
+      "groupName": "minor updates",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Add `"automerge": true` to the grouped patch and minor package rules in `renovate.json`. These PRs already go through CI; automerge lets them land without manual approval. Major updates still require review.