### PR TITLE
chore(ci): refresh playbook conformance across workflows

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('Cargo.toml') }}
 
       - name: Security – cargo deny
         env:

--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-other-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-versions:
+  test-all-versions:
     name: ubuntu-latest (${{ matrix.rust }})
     runs-on: ubuntu-latest
     permissions:
@@ -78,25 +78,34 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-other-platforms:
-    name: ${{ matrix.os }} (stable)
+  test-all-platforms:
+    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-          - os: macos-latest
-            target: aarch64-apple-darwin
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-latest
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
+          targets: ${{ matrix.target }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -34,13 +34,9 @@ fi
 
 set -x
 
-# test the default
+# test the default build (crate has no [features] table)
 cargo build
 cargo nextest run $NEXTEST_PROFILE
-
-# test all features
-cargo build --all-features
-cargo nextest run $NEXTEST_PROFILE --all-features
 
 # doc tests (not supported by nextest)
 cargo test --doc

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
+  "automergeStrategy": "merge-commit",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
@@ -22,7 +23,9 @@
     },
     {
       "description": "Group all patch updates into one PR",
-      "matchUpdateTypes": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "groupName": "patch updates",
       "automerge": true
     },


### PR DESCRIPTION
Second pass of the github-actions-playbook on this repo, picking up
items that drifted or were newly enforced upstream.

The biggest change is the compatibility matrix: the job keys now match
the playbook's canonical test-all-versions / test-all-platforms (so
required-check names line up), the display name is the target triple,
and Linux runs on *-unknown-linux-gnu — including a new x86_64 row
that wasn't previously covered. Earlier in this branch's history the
matrix briefly switched to musl per the playbook template; that was
reverted because tmux-lib is a pure-Rust library with no C deps and
ships no binaries, so musl buys nothing here.

Smaller fixes: scope the release publish job to the release deployment
environment, hash Cargo.toml in the cargo-audit cache key (Cargo.lock
is gitignored, so the previous key was effectively empty), drop the
redundant --all-features pass from test_full.sh (no [features] table),
and set Renovate's automergeStrategy: merge-commit so the auto-merge
mutation agrees with the ruleset on main.