### PR TITLE
ci: follow-up playbook fixes for cargo-audit and release

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -52,5 +52,5 @@ jobs:
 
       - name: Security – cargo pants
         run: |
-          cargo install --locked cargo-pants || true
+          cargo install --locked cargo-pants || command -v cargo-pants
           cargo pants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref, '-') }}
         run: |
           gh release create "${TAG_NAME}" \
+            --prerelease="${IS_PRERELEASE}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md


### PR DESCRIPTION
Two small workflow fixes carried over from recent github-actions-playbook
updates.

The cargo-audit job was installing cargo-pants with `|| true`, which
hides genuine install failures (network blip, yanked version, build
error) and surfaces them later as a misleading `command not found`.
Switch to `|| command -v cargo-pants` so a cache-hit "already installed"
still proceeds but a real install failure fails the step loudly.

The release job now marks tags containing `-` (v1.2.3-rc.1, -alpha.2,
…) as GitHub pre-releases. The release tag pattern already accepts
prerelease suffixes; previously they would have been published as a
normal "latest" release. The boolean is computed in the env block and
passed via `--prerelease=true|false` (cobra/pflag accepts that form for
any bool flag), so no word-splitting workarounds are needed.