### PR TITLE
ci: drop ~/.cargo/bin from cargo-audit cache paths

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -32,7 +32,6 @@ jobs:
         continue-on-error: false
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/


### PR DESCRIPTION
## Summary
- Removes `~/.cargo/bin/` from the cache `path:` list in `_cargo-audit.yml`.
- Aligns with playbook v1.1 hardening §7: the toolchain installer recreates that directory every run, and round-tripping it through tar can leave stale proxies on top of a fresh toolchain. `cargo-deny` is installed via `taiki-e/install-action`, so nothing here depends on the cached binary path.
- Matches the reference implementation (`gcode-language-server/.github/workflows/_cargo-audit.yml`).

## Test plan
- [ ] CI green on this branch (cargo-audit job still runs cleanly without the bin cache entry).