### PR TITLE
chore: add local verification workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md
+
+This file contains instructions for coding agents working in this repository.
+
+- Repository: <https://github.com/graelo/tmux-lib>
+- Prefer `gh` for GitHub operations.
+- Do not mention an agent or assistant in issues, pull requests, comments, or
+  commit messages.
+- Do not expose private local information, including machine-specific paths.
+
+## Project
+
+`tmux-lib` is a Rust library for reading and manipulating tmux state. Rust
+1.95.0 or later is required. The crate uses edition 2024.
+
+## Architecture
+
+- `src/client.rs`: client state and client-level tmux operations.
+- `src/server.rs`: server lifecycle and option management.
+- `src/session.rs`, `src/window.rs`, and `src/pane.rs`: public tmux resource
+  types, parsing, and operations.
+- `src/{session,window,pane}_id.rs`: strongly typed tmux identifiers and their
+  parsers.
+- `src/layout.rs`: parser for tmux window-layout strings.
+- `src/parse.rs`: shared parsers for tmux command output.
+- `src/error.rs`: public error type and command-output validation helpers.
+- `src/utils.rs`: helpers for tmux capture-buffer cleanup.
+- `tests/integration.rs`: end-to-end tests against a real tmux server; tests
+  clean up each session they create and skip when tmux is unavailable.
+
+## Verification
+
+The `Makefile` is the canonical definition of local verification tasks. **Read
+it before choosing or running verification commands**; do not duplicate its
+command implementations here. `make help` lists every target.
+
+The primary targets are:
+
+- `make check`: pre-push gate (formatting, linting, and tests).
+- `make check-all`: pre-PR gate (adds dependency, commit-message, Markdown,
+  and GitHub Actions security checks).
+- `make fix`: formats code and applies Clippy fixes.
+- `make md`: lints Markdown against `rumdl.toml`. Note the 80-column `MD013`
+  reflow rule — run this after editing any Markdown file.
+- `make ci-security`: runs the Poutine and Zizmor GitHub Actions scans.
+
+The check targets mirror the GitHub workflows and use locked dependency
+resolution where applicable. They assume their external tools (for example
+`cargo-nextest`, `cargo-deny`, `cargo-pants`, `convco`, `poutine`, `zizmor`,
+`rumdl`, and `cargo-llvm-cov`) are already installed locally.
+
+For focused Rust tests, use `cargo nextest run <test_name>` or
+`cargo nextest run <module::tests::name>`. The complete CI test sequence is
+implemented in `ci/test_full.sh`; its Nextest CI profile is configured in
+`.config/nextest.toml`.
+
+## Documentation and releases
+
+Keep user-facing documentation in sync with behavior:
+
+- `README.md` is the canonical crate overview. Keep its installation snippet,
+  supported Rust version, and usage guidance current.
+- Update `CHANGELOG.md` under `Unreleased` for user-visible changes.
+- For a release version bump, update `Cargo.toml`, `Cargo.lock`, and the
+  versioned section and comparison links in `CHANGELOG.md`. Create a
+  `vX.Y.Z` tag; the release workflow derives the release version from it.
+- Commit messages must follow `.convco` Conventional Commit rules. Use
+  `make commits` to check them.
+
+`Cargo.toml`, `Cargo.lock`, `deny.toml`, and the GitHub workflows define the
+release and supply-chain constraints. Preserve `--locked` behavior in Cargo
+commands that resolve dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- A `Makefile` defines canonical local verification tasks, with `make check`
+  as the pre-push gate and `make check-all` as the pre-PR gate
+- `rumdl.toml` applies consistent Markdown linting and formatting rules
+- `AGENTS.md` documents the project architecture, verification, and release
+  conventions for coding agents
+
+### Changed
+
+- Make `README.md` the canonical crate overview and remove its
+  `cargo-sync-readme` markers
+- Reduce crate-level Rust documentation to a link to the project README
+
 ## [0.5.0] - 2026-04-18
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+# Local task runner for pre-push / pre-PR verification.
+#
+# Usage:
+#   make check       # fmt + lint + test  (run before `git push`)
+#   make check-all   # adds audits, commit lint, docs, and CI security checks
+#   make fix         # auto-format and apply clippy fixes
+#
+# The check targets intentionally mirror .github/workflows/ci-essentials.yml so
+# a green local run predicts a green CI run. They assume their external tools
+# (cargo-nextest, cargo-deny, cargo-pants, convco, poutine, zizmor, rumdl, and
+# cargo-llvm-cov) are already installed locally.
+
+.DEFAULT_GOAL := help
+
+.PHONY: help fmt lint test check audit commits ci-security md check-all fix \
+	coverage
+
+help:  ## List available targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z_-]+:.*## / \
+		{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+fmt:  ## rustfmt --check (no changes)
+	cargo fmt --all -- --check
+
+lint:  ## clippy with warnings denied
+	cargo clippy --locked --all-targets -- -D warnings
+
+test:  ## full test suite (build + nextest + doc tests)
+	./ci/test_full.sh
+
+check: fmt lint test  ## pre-push gate: fmt + lint + test
+
+audit:  ## cargo-deny & cargo-pants: advisories, licenses, bans, sources
+	cargo deny --locked check
+	cargo pants
+
+commits:  ## verify commit messages follow Conventional Commits
+	convco check -c .convco
+
+ci-security:  ## audit GitHub Actions workflows
+	poutine --fail-on-violation analyze_local .
+	zizmor .github
+
+md:  ## lint Markdown against rumdl.toml
+	rumdl check .
+
+check-all: check audit commits ci-security md  ## pre-PR gate: everything
+
+fix:  ## auto-fix: rustfmt + clippy --fix
+	cargo fmt --all
+	cargo clippy --locked --all-targets --fix --allow-dirty --allow-staged -- -D warnings
+
+coverage:  ## HTML coverage report at target/llvm-cov/html/index.html
+	cargo llvm-cov --locked --html

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@
 [![minimum rustc 1.95](https://img.shields.io/badge/rustc-1.95+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/graelo/tmux-lib/actions/workflows/ci-essentials.yml/badge.svg)](https://github.com/graelo/tmux-lib/actions)
 
-<!-- cargo-sync-readme start -->
-
-Read or manipulate Tmux.
+Read or manipulate tmux.
 
 Version requirement: _rustc 1.95.0+_
 
 ```toml
 [dependencies]
-tmux-lib = "0.3"
+tmux-lib = "0.5"
 ```
 
 ## Getting started
@@ -23,6 +21,12 @@ Work in progress
 ## Caveats
 
 - This is a beta version
+
+## Development
+
+For local verification, read the [`Makefile`](Makefile) for the canonical task
+definitions, or run `make help` to list them: run `make check` before pushing
+and `make check-all` before opening a pull request.
 
 ## License
 
@@ -41,5 +45,3 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
 conditions.
-
-<!-- cargo-sync-readme end -->

--- a/rumdl.toml
+++ b/rumdl.toml
@@ -1,0 +1,26 @@
+# See the lints at https://github.com/rvben/rumdl/tree/main/docs
+[global]
+flavor = "mkdocs"
+disable = [
+  "MD007",  # prefer the flavor over MD007
+  "MD046",  # allow code blocks to be indented and fenced
+]
+
+[code-block-tools]
+enabled = true
+
+[code-block-tools.languages]
+python = { lint = ["ruff:check"], format = ["ruff:format"] }
+
+[MD013]
+line-length = 80
+code-blocks = false
+tables = false
+reflow = true
+
+[MD033]
+allowed-elements = ["kbd"]
+
+[MD060]
+enabled = true
+style = "aligned"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,7 @@
-//! Read or manipulate Tmux.
+//! Read or manipulate tmux.
 //!
-//! Version requirement: _rustc 1.95.0+_
-//!
-//! ```toml
-//! [dependencies]
-//! tmux-lib = "0.3"
-//! ```
-//!
-//! ## Getting started
-//!
-//! Work in progress
-//!
-//! ## Caveats
-//!
-//! - This is a beta version
-//!
-//! ## License
-//!
-//! Licensed under either of:
-//!
-//! - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-//!   <https://www.apache.org/licenses/LICENSE-2.0>)
-//! - MIT license ([LICENSE-MIT](LICENSE-MIT) or
-//!   <https://opensource.org/licenses/MIT>)
-//!
-//! at your option.
-//!
-//! ### Contribution
-//!
-//! Unless you explicitly state otherwise, any contribution intentionally
-//! submitted for inclusion in the work by you, as defined in the Apache-2.0
-//! license, shall be dual licensed as above, without any additional terms or
-//! conditions.
+//! See the [project README](https://github.com/graelo/tmux-lib#readme) for
+//! installation and usage guidance.
 
 pub mod error;
 


### PR DESCRIPTION
Add a Makefile as the canonical local verification entry point, with `check`
and `check-all` aligned to CI. Configure rumdl for Markdown checks and
document the workflow alongside contribution guidance. Make the README the
canonical crate overview and replace duplicate crate-root docs with a link.

Verified with `make check-all`.
